### PR TITLE
Fixing apt dependency list for horizon

### DIFF
--- a/files/apts/horizon
+++ b/files/apts/horizon
@@ -20,3 +20,4 @@ python-coverage
 python-cherrypy3 # why?
 python-migrate
 nodejs
+python-beautifulsoup


### PR DESCRIPTION
Adding python-beautifulsoup to the list of dependencies for horizon.
