### PR TITLE
Set a valid / unique SECRET_KEY others than the empty default.

### DIFF
--- a/files/horizon_settings.py
+++ b/files/horizon_settings.py
@@ -20,6 +20,10 @@ DATABASES = {
 CACHE_BACKEND = 'dummy://'
 SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
 
+# Set a secure and unique SECRET_KEY (the Django default is '')
+from horizon.utils import secret_key
+SECRET_KEY = secret_key.generate_or_read_from_file(os.path.join(LOCAL_PATH, '.secret_key_store'))
+
 # Send email to the console by default
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 # Or send them to /dev/null


### PR DESCRIPTION
Django's default SECRET_KEY is an empty string, which is actually not secure. Use horizon.util.secret key to generate a unique key and store it securely.
