### PR TITLE
support no_proxy environment variable

### DIFF
--- a/functions
+++ b/functions
@@ -17,6 +17,7 @@ function apt_get() {
     [[ "$(id -u)" = "0" ]] && sudo="env"
     $sudo DEBIAN_FRONTEND=noninteractive \
         http_proxy=$http_proxy https_proxy=$https_proxy \
+        no_proxy=$no_proxy \
         apt-get --option "Dpkg::Options::=--force-confold" --assume-yes "$@"
 }
 
@@ -461,6 +462,7 @@ function pip_install {
     sudo PIP_DOWNLOAD_CACHE=${PIP_DOWNLOAD_CACHE:-/var/cache/pip} \
         HTTP_PROXY=$http_proxy \
         HTTPS_PROXY=$https_proxy \
+        NO_PROXY=$no_proxy \
         $CMD_PIP install --use-mirrors $@
 }
 
@@ -491,6 +493,7 @@ function setup_develop() {
         sudo \
             HTTP_PROXY=$http_proxy \
             HTTPS_PROXY=$https_proxy \
+            NO_PROXY=$no_proxy \
             python setup.py develop \
     )
 }
@@ -544,6 +547,7 @@ function yum_install() {
     local sudo="sudo"
     [[ "$(id -u)" = "0" ]] && sudo="env"
     $sudo http_proxy=$http_proxy https_proxy=$https_proxy \
+        no_proxy=$no_proxy \
         yum install -y "$@"
 }
 

--- a/stack.sh
+++ b/stack.sh
@@ -81,6 +81,9 @@ fi
 if [[ -n "$https_proxy" ]]; then
     export https_proxy=$https_proxy
 fi
+if [[ -n "$no_proxy" ]]; then
+    export no_proxy=$no_proxy
+fi
 
 # Destination path for installation ``DEST``
 DEST=${DEST:-/opt/stack}


### PR DESCRIPTION
My devstack environment is located on the inside of proxy server, however I have a ubuntu package repository in my local server.
So I can get some ubuntu packages from local repository, however I have to get some other packages from public site via proxy server.
Therefore I hope devstack will support no_proxy environment variable.
Could you please confirm this commit?

Thank you in advance.
