### PR TITLE
prepare_guest_template.sh fails when there are multiple xs-tools iso's in ISO_DIR

### DIFF
--- a/tools/xen/prepare_guest_template.sh
+++ b/tools/xen/prepare_guest_template.sh
@@ -49,7 +49,7 @@ ISO_DIR="/opt/xensource/packages/iso"
 XS_TOOLS_FILE_NAME="xs-tools.deb"
 XS_TOOLS_PATH="/root/$XS_TOOLS_FILE_NAME"
 if [ -e "$ISO_DIR" ]; then
-    TOOLS_ISO=$(ls $ISO_DIR/xs-tools-*.iso)
+    TOOLS_ISO=$(ls -1 $ISO_DIR/xs-tools-*.iso | head -1)
     TMP_DIR=/tmp/temp.$RANDOM
     mkdir -p $TMP_DIR
     mount -o loop $TOOLS_ISO $TMP_DIR


### PR DESCRIPTION
In the case of two iso's ('xs-tools-6.0.2.iso' and 'xs-tools-6.0.2-1111.iso'), TOOLS_ISO gets set to 'xs-tools-6.0.2-1111.iso xs-tools-6.0.2.iso' This causes 'mount -o loop xs-tools-6.0.2-1111.iso xs-tools-6.0.2.iso $TMP_DIR' to get called, which fails as it's meant to be called with only one file. This fix simply sets TOOLS_ISO to the first iso that ls returns.
