### PR TITLE
Update keystone

### DIFF
--- a/files/apts/keystone
+++ b/files/apts/keystone
@@ -13,4 +13,3 @@ python-greenlet
 python-routes
 libldap2-dev
 libsasl2-dev
-python-bcrypt


### PR DESCRIPTION
keystone doesn't depend on bcrypt any more

see https://github.com/openstack/keystone/commit/48f2f650c8b622b55e67610081336055ec9a2c8e#keystone/common/utils.py
