### PR TITLE
Make sure custom grep options don't get in the way

### DIFF
--- a/stack.sh
+++ b/stack.sh
@@ -18,6 +18,9 @@
 
 # Learn more and get the most recent version at http://devstack.org
 
+# Make sure custom grep options don't get in the way
+unset GREP_OPTIONS
+
 # Keep track of the devstack directory
 TOP_DIR=$(cd $(dirname "$0") && pwd)
 


### PR DESCRIPTION
I saw this error when I first tried to run `stack.sh`:

```
$ ./stack.sh
/home/jason/github/devstack/functions: line 1406: (standard: command not found
/home/jason/github/devstack/lib/databases/mysql: line 147: (standard: command not found
/home/jason/github/devstack/lib/databases/postgresql: line 98: (standard: command not found
/home/jason/github/devstack/lib/database: line 124: (standard: command not found
/home/jason/github/devstack/lib/rpc_backend: line 163: (standard: command not found
WARNING: this script has not been tested on Debian-6.0.7.
[ERROR] ./stack.sh:108 If you wish to run this script anyway run with FORCE=yes
/home/jason/github/devstack/functions: line 98: (standard: command not found
```

It turns out I had the following set in my bash profile:

```
export GREP_OPTIONS="--color=auto -nH"
```

This fix should prevent this issue from occurring when `GREP_OPTIONS` has been customized.
