### PR TITLE
Update ceilometer repo destination.

### DIFF
--- a/stackrc
+++ b/stackrc
@@ -32,7 +32,7 @@ NOVA_ENABLED_APIS=ec2,osapi_compute,osapi_volume,metadata
 GIT_BASE=https://github.com
 
 # metering service
-CEILOMETER_REPO=https://github.com/stackforge/ceilometer.git
+CEILOMETER_REPO=https://github.com/openstack/ceilometer.git
 CEILOMETER_BRANCH=master
 
 # volume service


### PR DESCRIPTION
Stackforge ceilometer repo is not accessible anymore.
