### PR TITLE
Fix for system with proxy setting

### DIFF
--- a/stack.sh
+++ b/stack.sh
@@ -168,9 +168,9 @@ if [[ $EUID -eq 0 ]]; then
     chown -R $STACK_USER "$STACK_DIR"
     cd "$STACK_DIR"
     if [[ "$SHELL_AFTER_RUN" != "no" ]]; then
-        exec sudo -u $STACK_USER  bash -l -c "set -e; bash stack.sh; bash"
+        exec sudo -u $STACK_USER  bash -l -c "set -e; export http_proxy=$http_proxy; export https_proxy=$https_proxy; export no_proxy=$noproxy; bash stack.sh; bash"
     else
-        exec sudo -u $STACK_USER bash -l -c "set -e; source stack.sh"
+        exec sudo -u $STACK_USER bash -l -c "set -e; export http_proxy=$http_proxy; export https_proxy=$https_proxy; export no_proxy=$noproxy; source stack.sh"
     fi
     exit 1
 else


### PR DESCRIPTION
in original code: stack.sh:~170
 170     if [[ "$SHELL_AFTER_RUN" != "no" ]]; then
 171         exec sudo -u $STACK_USER  bash -l -c "set -e; bash stack.sh; bash"
 172     else
 173         exec sudo -u $STACK_USER bash -l -c "set -e; source stack.sh"
 174     fi

It is unlikely that any env variable is passed to next step.
So I add a few piece of code and it works for me.
