### PR TITLE
'run_tests.sh --compilemessages' requires gettext.

### DIFF
--- a/files/apts/general
+++ b/files/apts/general
@@ -21,3 +21,4 @@ euca2ools # only for testing client
 tar
 python-cmd2 # dist:precise
 python-netaddr
+gettext


### PR DESCRIPTION
When I ran 'run_tests.sh --compilemessages', I got error and this commit fixes it.
