### PR TITLE
Apache's virtual host name

### DIFF
--- a/files/apache-horizon.template
+++ b/files/apache-horizon.template
@@ -1,4 +1,7 @@
 <VirtualHost *:80>
+
+	ServerName %APACHE_SERVER_NAME%
+
     WSGIScriptAlias / %HORIZON_DIR%/openstack_dashboard/wsgi/django.wsgi
     WSGIDaemonProcess horizon user=%USER% group=%GROUP% processes=3 threads=10 home=%HORIZON_DIR%
     WSGIApplicationGroup %{GLOBAL}

--- a/lib/horizon
+++ b/lib/horizon
@@ -139,6 +139,7 @@ function init_horizon() {
         s,%GROUP%,$APACHE_GROUP,g;
         s,%HORIZON_DIR%,$HORIZON_DIR,g;
         s,%APACHE_NAME%,$APACHE_NAME,g;
+		s,%APACHE_SERVER_NAME%,$APACHE_SERVER_NAME,g;
         s,%DEST%,$DEST,g;
         s,%HORIZON_REQUIRE%,$HORIZON_REQUIRE,g;
     \" $FILES/apache-horizon.template >$horizon_conf"

--- a/stack.sh
+++ b/stack.sh
@@ -752,6 +752,11 @@ fi
 
 if is_service_enabled horizon; then
     # dashboard
+	if [ ! $APACHE_SERVER_NAME ]; then
+		eval "APACHE_SERVER_NAME=openstack.loc"
+		echo "APACHE_SERVER_NAME=openstack.loc" >> $localrc
+	fi
+	echo "Setting APACHE_SERVER_NAME=$APACHE_SERVER_NAME"
     install_horizon
     configure_horizon
 fi


### PR DESCRIPTION
Additional parameter to localrc APACHE_SERVER_NAME, which specifies the server name for the apache's virtual host. Helpful if you use apache for other applications too.

For example, I use apache for some PHP applications and that's why default IP offered by devstack does not work for me. So I added a variable APACHE_SERVER_NAME. Default value of APACHE_SERVER_NAME is openstack.loc. It also has to be added to /etc/hosts on your PC.
