### PR TITLE
Change fetch for management ip address to a more global approach

### DIFF
--- a/tools/xen/functions
+++ b/tools/xen/functions
@@ -202,7 +202,7 @@ function xenapi_ip_on() {
     local bridge_or_net_name
     bridge_or_net_name=$1
 
-    ifconfig $(bridge_for "$bridge_or_net_name") | grep "inet addr" | cut -d ":" -f2 | sed "s/ .*//"
+    ifconfig $(bridge_for "$bridge_or_net_name") | grep "inet " | cut -d ":" -f2 | sed "s/ .*//"
 }
 
 function xenapi_is_listening_on() {


### PR DESCRIPTION
Hi all,

if you grep for inet addr it will not work on non english based xenservers.
In german it is inet Adress instead of inet addr so if you cut the grep to "inet " it will run on most of the languages.
Best Regards
Arne
