### PR TITLE
Fix lxc-docker installation for Ubuntu 13.04

### DIFF
--- a/tools/docker/install_docker.sh
+++ b/tools/docker/install_docker.sh
@@ -38,7 +38,7 @@ curl https://get.docker.io/gpg | sudo apt-key add -
 install_package python-software-properties && \
     sudo sh -c "echo deb $DOCKER_APT_REPO docker main > /etc/apt/sources.list.d/docker.list"
 apt_get update
-install_package --force-yes lxc-docker=${DOCKER_PACKAGE_VERSION} socat
+install_package --force-yes lxc-docker-${DOCKER_PACKAGE_VERSION} socat
 
 # Start the daemon - restart just in case the package ever auto-starts...
 restart_service docker


### PR DESCRIPTION
Installation fails for Ubuntu 13.04 with `E: Version '0.6.1' for 'lxc-docker' was not found` message.

It solves the problem, but I don't know how it would behave for other distros.
