### PR TITLE
Install python-psycopg2 (needed in case of postgresql backend)

### DIFF
--- a/files/apts/keystone
+++ b/files/apts/keystone
@@ -7,6 +7,7 @@ sqlite3
 python-pysqlite2
 python-sqlalchemy
 python-mysqldb
+python-psycopg2
 python-webob
 python-greenlet
 python-routes

--- a/files/apts/neutron
+++ b/files/apts/neutron
@@ -15,6 +15,7 @@ python-kombu
 python-eventlet
 python-sqlalchemy
 python-mysqldb
+python-psycopg2
 python-pyudev
 python-qpid # dist:precise
 dnsmasq-base

--- a/files/apts/nova
+++ b/files/apts/nova
@@ -5,6 +5,7 @@ parted
 iputils-arping
 mysql-server # NOPRIME
 python-mysqldb
+python-psycopg2
 python-xattr # needed for glance which is needed for nova --- this shouldn't be here
 python-lxml # needed for glance which is needed for nova --- this shouldn't be here
 gawk


### PR DESCRIPTION
When the alternate database postgresql is selected, the python library psycopg2 has to be installed too.
