### PR TITLE
Update hypervisor-docker to remove file copy that fails.

### DIFF
--- a/lib/nova_plugins/hypervisor-docker
+++ b/lib/nova_plugins/hypervisor-docker
@@ -56,7 +56,7 @@ function configure_nova_hypervisor() {
     iniset $NOVA_CONF DEFAULT compute_driver docker.DockerDriver
     iniset $GLANCE_API_CONF DEFAULT container_formats ami,ari,aki,bare,ovf,docker
 
-    sudo cp -p ${DOCKER_DIR}/nova-driver/docker.filters $NOVA_CONF_DIR/rootwrap.d
+    #sudo cp -p ${DOCKER_DIR}/nova-driver/docker.filters $NOVA_CONF_DIR/rootwrap.d
 }
 
 # install_nova_hypervisor() - Install external components


### PR DESCRIPTION
i think this is no longer neeeded?    I was getting errors that the source file didn't exist,  I checked it out and not only that but the destination file was there.  Removing out the copy line got the docker driver install working for me.
