### PR TITLE
write nova.conf [keystone_authtoken] section to avoid ERROR: Unauthorized (HTTP 401)

### DIFF
--- a/lib/nova
+++ b/lib/nova
@@ -492,6 +492,22 @@ function create_nova_conf() {
     iniset $NOVA_CONF DEFAULT ec2_dmz_host "$EC2_DMZ_HOST"
     iniset_rpc_backend nova $NOVA_CONF DEFAULT
     iniset $NOVA_CONF DEFAULT glance_api_servers "$GLANCE_HOSTPORT"
+
+    # [keystone_authtoken]
+    # Host providing the admin Identity API endpoint
+    iniset $NOVA_CONF keystone_authtoken auth_host $KEYSTONE_SERVICE_HOST
+    # Port of the admin Identity API endpoint
+    iniset $NOVA_CONF keystone_authtoken auth_port $KEYSTONE_SERVICE_PORT
+    # Protocol of the admin Identity API endpoint
+    iniset $NOVA_CONF keystone_authtoken auth_protocol $KEYSTONE_SERVICE_PROTOCOL
+    # Keystone service account tenant name to validate user tokens
+    iniset $NOVA_CONF keystone_authtoken admin_tenant_name $SERVICE_TENANT_NAME
+    # Keystone account username
+    iniset $NOVA_CONF keystone_authtoken admin_user nova
+    # Keystone account password
+    iniset $NOVA_CONF keystone_authtoken admin_password $ADMIN_PASSWORD
+    iniset $NOVA_CONF keystone_authtoken auth_version v2.0
+
 }
 
 function init_nova_cells() {


### PR DESCRIPTION
I was having errors like ERROR: Unauthorized (HTTP 401) in the latest devstack.  It turned out nova was sending HTTPS to keystone which was expecting HTTP.  The latest nova sets up [keystone_authtoken] section in nova.conf.sample, but lib/nova in devstack builds nova.conf from scratch.  So. I added a block to set up keystone_authtoken in lib/nova
