### PR TITLE
Allow dot in interface name in get_default_host_ip()

### DIFF
--- a/functions
+++ b/functions
@@ -218,7 +218,7 @@ function get_default_host_ip() {
     local host_ip=$4
 
     # Find the interface used for the default route
-    host_ip_iface=${host_ip_iface:-$(ip route | sed -n '/^default/{ s/.*dev \(\w\+\)\s\+.*/\1/; p; }' | head -1)}
+    host_ip_iface=${host_ip_iface:-$(ip route | sed -n '/^default/{ s/.*dev \([a-z.0-9_]\+\)\s\+.*/\1/; p; }' | head -1)}
     # Search for an IP unless an explicit is set by ``HOST_IP`` environment variable
     if [ -z "$host_ip" -o "$host_ip" == "dhcp" ]; then
         host_ip=""


### PR DESCRIPTION
When using [vlan](https://wiki.ubuntu.com/vlan), there may be `.` dot in interface name.
