### PR TITLE
Make sure the umask is 022.

### DIFF
--- a/stack.sh
+++ b/stack.sh
@@ -98,6 +98,9 @@ export_proxy_variables
 # Destination path for installation ``DEST``
 DEST=${DEST:-/opt/stack}
 
+# We are going to be installing various packages that need to be
+# world-readable, so ensure our umask isn't too strict.
+umask 022
 
 # Sanity Check
 # ------------


### PR DESCRIPTION
Without this various things get installed as root and are unusable once
running as a normal user.  This is unfortunately the case of all Python
packages, as they don't use `install' or a package format that preserves
file permissions.  This also affects various other random files created
during initial setup, such as /etc/polkit-1/rules.d/50-libvirt-$USER.rules
and others.
