### PR TITLE
Added python-dev to dependencies to fix "No such file or directory" error

### DIFF
--- a/files/apts/neutron
+++ b/files/apts/neutron
@@ -4,6 +4,7 @@ iputils-ping
 iputils-arping
 mysql-server #NOPRIME
 sudo
+python-dev
 python-boto
 python-iso8601
 python-paste

--- a/files/apts/nova
+++ b/files/apts/nova
@@ -22,6 +22,7 @@ genisoimage # required for config_drive
 rabbitmq-server # NOPRIME
 qpidd # dist:precise NOPRIME
 socat # used by ajaxterm
+python-dev
 python-mox
 python-paste
 python-migrate


### PR DESCRIPTION
Added python-dev to dependencies to fix "No such file or directory" errors for nova and neutron when creating a separate network or compute node (running stack.sh) on a clean machine.
