### PR TITLE
Fixed SSL certificate problem

### DIFF
--- a/tools/install_pip.sh
+++ b/tools/install_pip.sh
@@ -64,7 +64,7 @@ function get_versions() {
 function install_get_pip() {
     if [[ ! -r $FILES/get-pip.py ]]; then
         (cd $FILES; \
-            curl -O $PIP_GET_PIP_URL; \
+            curl -kO $PIP_GET_PIP_URL; \
         )
     fi
     sudo -E python $FILES/get-pip.py
@@ -72,7 +72,7 @@ function install_get_pip() {
 
 function install_pip_tarball() {
     (cd $FILES; \
-        curl -O $PIP_TAR_URL; \
+        curl -kO $PIP_TAR_URL; \
         tar xvfz pip-$INSTALL_PIP_VERSION.tar.gz 1>/dev/null; \
         cd pip-$INSTALL_PIP_VERSION; \
         sudo -E python setup.py install 1>/dev/null; \


### PR DESCRIPTION
- cd /home/dot/devstack/files
- curl -O https://pypi.python.org/packages/source/p/pip/pip-1.4.1.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (60) SSL certificate problem, verify that the CA cert is OK. Details:
  error:14090086:SSL routines:SSL3_GET_SERVER_CERTIFICATE:certificate verify failed
  More details here: http://curl.haxx.se/docs/sslcerts.html

curl performs SSL certificate verification by default, using a "bundle"
 of Certificate Authority (CA) public keys (CA certs). If the default
 bundle file isn't adequate, you can specify an alternate file
 using the --cacert option.
If this HTTPS server uses a certificate signed by a CA represented in
 the bundle, the certificate verification probably failed due to a
 problem with the certificate (it might be expired, or the name might
 not match the domain name in the URL).
