### PR TITLE
Perform safety checks in create-stack-user.sh

### DIFF
--- a/tools/create-stack-user.sh
+++ b/tools/create-stack-user.sh
@@ -15,23 +15,39 @@
 # and it was time for this nonsense to stop.  Run this script as root to create
 # the user and configure sudo.
 
+set -e
 
 # Keep track of the devstack directory
 TOP_DIR=$(cd $(dirname "$0")/.. && pwd)
 
 # Import common functions
-source $TOP_DIR/functions
+if [[ -e $TOP_DIR/functions ]]; then
+    source $TOP_DIR/functions
+else
+    echo "Could not source $TOP_DIR/functions. Exiting."
+    exit 1
+fi
 
 # Determine what system we are running on.  This provides ``os_VENDOR``,
 # ``os_RELEASE``, ``os_UPDATE``, ``os_PACKAGE``, ``os_CODENAME``
 # and ``DISTRO``
 GetDistro
 
-# Needed to get ``ENABLED_SERVICES``
-source $TOP_DIR/stackrc
+# Needed to get ``ENABLED_SERVICES`` and ``STACK_USER``
+if [[ -e $TOP_DIR/stackrc ]]; then
+    source $TOP_DIR/stackrc
+else
+    echo "Could not source $TOP_DIR/stackrc. Exiting."
+    exit 1
+fi
 
 # Give the non-root user the ability to run as **root** via ``sudo``
 is_package_installed sudo || install_package sudo
+
+if [[ -z "$STACK_USER" ]]; then
+    echo "STACK_USER is not set. Exiting."
+    exit 1
+fi
 
 if ! getent group $STACK_USER >/dev/null; then
     echo "Creating a group called $STACK_USER"


### PR DESCRIPTION
This adds some safety checks to the stack user creation script.

This includes:
- Using set -e to exit early on errors
- Make sure the `functions` script exists
- Make sure the `stackrc` script exists
- Make sure STACK_USER is set before doing anything with it

Why is this necessary? I managed to run this with `sh`, STACK_USER did not get set, and the end result was a broken sudoers file. Not fun.
