### PR TITLE
Updated Debian repo to Icehouse

### DIFF
--- a/stack.sh
+++ b/stack.sh
@@ -217,8 +217,8 @@ sudo mv $TEMPFILE /etc/sudoers.d/50_stack_sh
 # The Debian Wheezy official repositories do not contain all required packages,
 # add gplhost repository.
 if [[ "$os_VENDOR" =~ (Debian) ]]; then
-    echo 'deb http://archive.gplhost.com/debian grizzly main' | sudo tee /etc/apt/sources.list.d/gplhost_wheezy-backports.list
-    echo 'deb http://archive.gplhost.com/debian grizzly-backports main' | sudo tee -a /etc/apt/sources.list.d/gplhost_wheezy-backports.list
+    echo 'deb http://archive.gplhost.com/debian icehouse main' | sudo tee /etc/apt/sources.list.d/gplhost_wheezy-backports.list
+    echo 'deb http://archive.gplhost.com/debian icehouse-backports main' | sudo tee -a /etc/apt/sources.list.d/gplhost_wheezy-backports.list
     apt_get update
     apt_get install --force-yes gplhost-archive-keyring
 fi


### PR DESCRIPTION
Why the repository path for Debian isn't ever changed? Repository contains newest Icehouse, but stack.sh still uses Grizzly release.
