### PR TITLE
add support for defining url of get-pip.py.

### DIFF
--- a/stack.sh
+++ b/stack.sh
@@ -662,6 +662,7 @@ source $TOP_DIR/tools/install_prereqs.sh
 
 # Configure an appropriate python environment
 if [[ "$OFFLINE" != "True" ]]; then
+    export PIP_GET_PIP_URL
     $TOP_DIR/tools/install_pip.sh
 fi
 

--- a/tools/install_pip.sh
+++ b/tools/install_pip.sh
@@ -24,7 +24,7 @@ source $TOP_DIR/functions
 
 FILES=$TOP_DIR/files
 
-PIP_GET_PIP_URL=https://bootstrap.pypa.io/get-pip.py
+PIP_GET_PIP_URL=${PIP_GET_PIP_URL:-"https://bootstrap.pypa.io/get-pip.py"}
 LOCAL_PIP="$FILES/$(basename $PIP_GET_PIP_URL)"
 
 GetDistro


### PR DESCRIPTION
In some case, the original url of get-pip.py in devstack may not be accessful. (Local network, China etc.)
