### PR TITLE
$LOGDIR might not be initialized

### DIFF
--- a/stack.sh
+++ b/stack.sh
@@ -623,7 +623,9 @@ function exit_trap {
 
     if [[ $r -ne 0 ]]; then
         echo "Error on exit"
-        ./tools/worlddump.py -d $LOGDIR
+        if [[ -n "$LOGDIR" ]]; then
+            ./tools/worlddump.py -d $LOGDIR
+        fi
     fi
 
     exit $r


### PR DESCRIPTION
Following http://devstack.org/guides/single-vm.html, where `LOGFILE` is not set, a Git timeout led to a secondary error when `worddump` was invoked with an empty argument for `-d`. 
