### PR TITLE
apache requires .conf for sites

### DIFF
--- a/lib/swift
+++ b/lib/swift
@@ -162,14 +162,14 @@ function _config_swift_apache_wsgi {
     local proxy_port=${SWIFT_DEFAULT_BIND_PORT:-8080}
 
     # copy proxy vhost and wsgi file
-    sudo cp ${SWIFT_DIR}/examples/apache2/proxy-server.template ${apache_vhost_dir}/proxy-server
+    sudo cp ${SWIFT_DIR}/examples/apache2/proxy-server.template ${apache_vhost_dir}/proxy-server.conf
     sudo sed -e "
         /^#/d;/^$/d;
         s/%PORT%/$proxy_port/g;
         s/%SERVICENAME%/proxy-server/g;
         s/%APACHE_NAME%/${APACHE_NAME}/g;
         s/%USER%/${STACK_USER}/g;
-    " -i ${apache_vhost_dir}/proxy-server
+    " -i ${apache_vhost_dir}/proxy-server.conf
     enable_apache_site proxy-server
 
     sudo cp ${SWIFT_DIR}/examples/wsgi/proxy-server.wsgi.template ${SWIFT_APACHE_WSGI_DIR}/proxy-server.wsgi
@@ -184,13 +184,13 @@ function _config_swift_apache_wsgi {
         container_port=$[CONTAINER_PORT_BASE + 10 * ($node_number - 1)]
         account_port=$[ACCOUNT_PORT_BASE + 10 * ($node_number - 1)]
 
-        sudo cp ${SWIFT_DIR}/examples/apache2/object-server.template ${apache_vhost_dir}/object-server-${node_number}
+        sudo cp ${SWIFT_DIR}/examples/apache2/object-server.template ${apache_vhost_dir}/object-server-${node_number}.conf
         sudo sed -e "
             s/%PORT%/$object_port/g;
             s/%SERVICENAME%/object-server-${node_number}/g;
             s/%APACHE_NAME%/${APACHE_NAME}/g;
             s/%USER%/${STACK_USER}/g;
-        " -i ${apache_vhost_dir}/object-server-${node_number}
+        " -i ${apache_vhost_dir}/object-server-${node_number}.conf
         enable_apache_site object-server-${node_number}
 
         sudo cp ${SWIFT_DIR}/examples/wsgi/object-server.wsgi.template ${SWIFT_APACHE_WSGI_DIR}/object-server-${node_number}.wsgi
@@ -199,14 +199,14 @@ function _config_swift_apache_wsgi {
             s/%SERVICECONF%/object-server\/${node_number}.conf/g;
         " -i ${SWIFT_APACHE_WSGI_DIR}/object-server-${node_number}.wsgi
 
-        sudo cp ${SWIFT_DIR}/examples/apache2/container-server.template ${apache_vhost_dir}/container-server-${node_number}
+        sudo cp ${SWIFT_DIR}/examples/apache2/container-server.template ${apache_vhost_dir}/container-server-${node_number}.conf
         sudo sed -e "
             /^#/d;/^$/d;
             s/%PORT%/$container_port/g;
             s/%SERVICENAME%/container-server-${node_number}/g;
             s/%APACHE_NAME%/${APACHE_NAME}/g;
             s/%USER%/${STACK_USER}/g;
-        " -i ${apache_vhost_dir}/container-server-${node_number}
+        " -i ${apache_vhost_dir}/container-server-${node_number}.conf
         enable_apache_site container-server-${node_number}
 
         sudo cp ${SWIFT_DIR}/examples/wsgi/container-server.wsgi.template ${SWIFT_APACHE_WSGI_DIR}/container-server-${node_number}.wsgi
@@ -215,14 +215,14 @@ function _config_swift_apache_wsgi {
             s/%SERVICECONF%/container-server\/${node_number}.conf/g;
         " -i ${SWIFT_APACHE_WSGI_DIR}/container-server-${node_number}.wsgi
 
-        sudo cp ${SWIFT_DIR}/examples/apache2/account-server.template ${apache_vhost_dir}/account-server-${node_number}
+        sudo cp ${SWIFT_DIR}/examples/apache2/account-server.template ${apache_vhost_dir}/account-server-${node_number}.conf
         sudo sed -e "
             /^#/d;/^$/d;
             s/%PORT%/$account_port/g;
             s/%SERVICENAME%/account-server-${node_number}/g;
             s/%APACHE_NAME%/${APACHE_NAME}/g;
             s/%USER%/${STACK_USER}/g;
-        " -i ${apache_vhost_dir}/account-server-${node_number}
+        " -i ${apache_vhost_dir}/account-server-${node_number}.conf
         enable_apache_site account-server-${node_number}
 
         sudo cp ${SWIFT_DIR}/examples/wsgi/account-server.wsgi.template ${SWIFT_APACHE_WSGI_DIR}/account-server-${node_number}.wsgi


### PR DESCRIPTION
Using ubuntu 14.04, a2ensite fails when the vhost files do not end in .conf. This change hasn't been tested elsewhere.
