### PR TITLE
neutron script need uuidgen binary

### DIFF
--- a/files/debs/neutron
+++ b/files/debs/neutron
@@ -24,3 +24,4 @@ qpidd # NOPRIME
 sqlite3
 vlan
 radvd # NOPRIME
+uuid-runtime


### PR DESCRIPTION
When using unstack.sh script on Debian Wheezy, i saw a failing call on uuidgen binary:

```
$ ./unstack.sh 
/home/stack/devstack/lib/neutron: line 83: uuidgen: command not found
Site keystone disabled.
[...]
```
