### PR TITLE
Fedora image link broken. Updated to a working version.

### DIFF
--- a/stackrc
+++ b/stackrc
@@ -577,7 +577,7 @@ esac
 if [[ "$ENABLED_SERVICES" =~ 'h-api' ]]; then
     case "$VIRT_DRIVER" in
         libvirt|ironic)
-            HEAT_CFN_IMAGE_URL=${HEAT_CFN_IMAGE_URL:-"https://download.fedoraproject.org/pub/alt/openstack/20/x86_64/Fedora-x86_64-20-20140618-sda.qcow2"}
+            HEAT_CFN_IMAGE_URL=${HEAT_CFN_IMAGE_URL:-"http://archive.fedoraproject.org/pub/alt/openstack/20/x86_64/Fedora-x86_64-20-20140618-sda.qcow2"}
             IMAGE_URLS+=",$HEAT_CFN_IMAGE_URL"
             ;;
         *)
@@ -602,7 +602,7 @@ fi
 PRECACHE_IMAGES=$(trueorfalse False PRECACHE_IMAGES)
 if [[ "$PRECACHE_IMAGES" == "True" ]]; then
     # staging in update for nodepool
-    IMAGE_URL="https://download.fedoraproject.org/pub/alt/openstack/20/x86_64/Fedora-x86_64-20-20140618-sda.qcow2"
+    IMAGE_URL="http://archive.fedoraproject.org/pub/alt/openstack/20/x86_64/Fedora-x86_64-20-20140618-sda.qcow2"
     if ! [[ "$IMAGE_URLS"  =~ "$IMAGE_URL" ]]; then
         IMAGE_URLS+=",$IMAGE_URL"
     fi


### PR DESCRIPTION
The broken link is also present in the stable branches as well.