### PR TITLE
Fix upgrade from juno to kilo

### DIFF
--- a/functions-common
+++ b/functions-common
@@ -798,8 +798,8 @@ function get_or_create_service {
         openstack service show $1 -f value -c id 2>/dev/null ||
         # Creates new service if not exists
         openstack service create \
-            $2 \
-            --name $1 \
+            $1 \
+            --type $2 \
             --description="$3" \
             -f value -c id
     )


### PR DESCRIPTION
Revert [789af5c]. This commit doesn't work the upgrade from juno to kilo (or current master branch).
Related-bugs: #1446600, #1404073

I've followed the next steps for upgrade devstack from juno to kilo:

    cd ~/devstack
    ./unstack.sh
    sudo rm -rf /opt/stack/
    git checkout kilo
    git pull
    ./stack.sh

The function get_or_create_service generates an openstack command with a bad syntax e.g.:

    openstack service create computev21 --name novav21 '--description=Nova Compute Service V2.1' -f value -c id
    openstack service create: error: argument --type is required

This produces other relative errors...