### PR TITLE
missing jsonrpclib plugin for neutron - ml2 plugin

### DIFF
--- a/lib/neutron_plugins/ml2
+++ b/lib/neutron_plugins/ml2
@@ -128,6 +128,11 @@ function neutron_plugin_configure_service {
     fi
 }
 
+
+function neutron_plugin_install_agent_packages() {
+    install_package python-jsonrpclib
+} 
+
 function has_neutron_plugin_security_group {
     return 0
 }


### PR DESCRIPTION
Orignal patch from this link
https://launchpadlibrarian.net/149548064/devstack.diff