### PR TITLE
Devstack to support an IPv6 infra installation

### DIFF
--- a/lib/cinder
+++ b/lib/cinder
@@ -202,6 +202,7 @@ function configure_cinder {
     iniset $CINDER_CONF DEFAULT verbose True
 
     iniset $CINDER_CONF DEFAULT iscsi_helper "$CINDER_ISCSI_HELPER"
+    iniset $CINDER_CONF DEFAULT osapi_volume_listen "$HOST_IP"
     iniset $CINDER_CONF database connection `database_connection_url cinder`
     iniset $CINDER_CONF DEFAULT api_paste_config $CINDER_API_PASTE_INI
     iniset $CINDER_CONF DEFAULT rootwrap_config "$CINDER_CONF_DIR/rootwrap.conf"

--- a/lib/databases/mysql
+++ b/lib/databases/mysql
@@ -83,10 +83,10 @@ function configure_database_mysql {
 
     # Now update ``my.cnf`` for some local needs and restart the mysql service
 
-    # Change ‘bind-address’ from localhost (127.0.0.1) to any (0.0.0.0) and
+    # Change ‘bind-address’ from localhost (127.0.0.1) to any (::) and
     # set default db type to InnoDB
     sudo bash -c "source $TOP_DIR/functions && \
-        iniset $my_conf mysqld bind-address 0.0.0.0 && \
+        iniset $my_conf mysqld bind-address '::' && \
         iniset $my_conf mysqld sql_mode STRICT_ALL_TABLES && \
         iniset $my_conf mysqld default-storage-engine InnoDB"
 

--- a/lib/glance
+++ b/lib/glance
@@ -105,6 +105,7 @@ function configure_glance {
     # Copy over our glance configurations and update them
     cp $GLANCE_DIR/etc/glance-registry.conf $GLANCE_REGISTRY_CONF
     iniset $GLANCE_REGISTRY_CONF DEFAULT debug $ENABLE_DEBUG_LOG_LEVEL
+    iniset $GLANCE_REGISTRY_CONF DEFAULT bind_host $HOST_IP
     inicomment $GLANCE_REGISTRY_CONF DEFAULT log_file
     local dburl=`database_connection_url glance`
     iniset $GLANCE_REGISTRY_CONF DEFAULT sql_connection $dburl
@@ -118,6 +119,7 @@ function configure_glance {
 
     cp $GLANCE_DIR/etc/glance-api.conf $GLANCE_API_CONF
     iniset $GLANCE_API_CONF DEFAULT debug $ENABLE_DEBUG_LOG_LEVEL
+    iniset $GLANCE_API_CONF DEFAULT bind_host $HOST_IP
     inicomment $GLANCE_API_CONF DEFAULT log_file
     iniset $GLANCE_API_CONF DEFAULT sql_connection $dburl
     iniset $GLANCE_API_CONF DEFAULT use_syslog $SYSLOG
@@ -138,6 +140,7 @@ function configure_glance {
 
     # Store specific configs
     iniset $GLANCE_API_CONF DEFAULT filesystem_store_datadir $GLANCE_IMAGE_DIR/
+    iniset $GLANCE_API_CONF DEFAULT registry_host $GLANCE_SERVICE_HOST
 
     # NOTE(flaper87): Until Glance is fully migrated, set these configs in both
     # sections.
@@ -208,6 +211,7 @@ function configure_glance {
     iniset $GLANCE_CACHE_CONF DEFAULT admin_user glance
     iniuncomment $GLANCE_CACHE_CONF DEFAULT auth_password
     iniset $GLANCE_CACHE_CONF DEFAULT admin_password $SERVICE_PASSWORD
+    iniset $GLANCE_CACHE_CONF DEFAULT registry_host $GLANCE_SERVICE_HOST
 
     # Store specific confs
     # NOTE(flaper87): Until Glance is fully migrated, set these configs in both

--- a/lib/keystone
+++ b/lib/keystone
@@ -254,6 +254,7 @@ function configure_keystone {
         iniset $KEYSTONE_CONF eventlet_server admin_port $KEYSTONE_AUTH_PORT_INT
     fi
 
+    iniset $KEYSTONE_CONF DEFAULT bind_host $HOST_IP
     iniset $KEYSTONE_CONF DEFAULT admin_token "$SERVICE_TOKEN"
 
     if [[ "$KEYSTONE_TOKEN_FORMAT" != "" ]]; then
@@ -468,6 +469,7 @@ function configure_auth_token_middleware {
     iniset $conf_file $section project_domain_id default
 
     iniset $conf_file $section auth_uri $KEYSTONE_SERVICE_URI
+    iniset $conf_file $section identity_uri $KEYSTONE_SERVICE_URI
     iniset $conf_file $section cafile $SSL_BUNDLE_FILE
     iniset $conf_file $section signing_dir $signing_dir
 }

--- a/lib/neutron-legacy
+++ b/lib/neutron-legacy
@@ -860,6 +860,7 @@ function _configure_neutron_common {
     iniset $NEUTRON_CONF database connection `database_connection_url $Q_DB_NAME`
     iniset $NEUTRON_CONF DEFAULT state_path $DATA_DIR/neutron
     iniset $NEUTRON_CONF DEFAULT use_syslog $SYSLOG
+    iniset $NEUTRON_CONF DEFAULT bind_host $HOST_IP
     # If addition config files are set, make sure their path name is set as well
     if [[ ${#Q_PLUGIN_EXTRA_CONF_FILES[@]} > 0 && $Q_PLUGIN_EXTRA_CONF_PATH == '' ]]; then
         die $LINENO "Neutron additional plugin config not set.. exiting"

--- a/lib/neutron_plugins/ml2
+++ b/lib/neutron_plugins/ml2
@@ -105,7 +105,10 @@ function neutron_plugin_configure_service {
     fi
 
     # Since we enable the tunnel TypeDrivers, also enable a local_ip
-    iniset /$Q_PLUGIN_CONF_FILE ovs local_ip $TUNNEL_ENDPOINT_IP
+    if [[ "$ENABLE_TENANT_TUNNELS" == "True" ]]; then
+        # Set local_ip if TENANT_TUNNELS are enabled.
+        iniset /$Q_PLUGIN_CONF_FILE ovs local_ip $TUNNEL_ENDPOINT_IP
+    fi
 
     populate_ml2_config /$Q_PLUGIN_CONF_FILE ml2 mechanism_drivers=$Q_ML2_PLUGIN_MECHANISM_DRIVERS
 

--- a/lib/nova
+++ b/lib/nova
@@ -403,6 +403,12 @@ function create_nova_conf {
     iniset $NOVA_CONF DEFAULT s3_host "$SERVICE_HOST"
     iniset $NOVA_CONF DEFAULT s3_port "$S3_SERVICE_PORT"
     iniset $NOVA_CONF DEFAULT my_ip "$HOST_IP"
+    iniset $NOVA_CONF DEFAULT s3_listen "$HOST_IP"
+    iniset $NOVA_CONF DEFAULT novncproxy_host "$HOST_IP"
+    iniset $NOVA_CONF DEFAULT metadata_host "$HOST_IP"
+    iniset $NOVA_CONF DEFAULT metadata_listen "$HOST_IP"
+    iniset $NOVA_CONF DEFAULT ec2_listen "$HOST_IP"
+    iniset $NOVA_CONF DEFAULT osapi_compute_listen "$HOST_IP"
     iniset $NOVA_CONF database connection `database_connection_url nova`
     iniset $NOVA_CONF DEFAULT instance_name_template "${INSTANCE_NAME_PREFIX}%08x"
     iniset $NOVA_CONF osapi_v3 enabled "True"


### PR DESCRIPTION
Currently devstack provides the necessary support to have an IPv4 based
OpenStack infrastructure where the services are binded to IPv4 addresses.
However, it does not support an IPv6 infra installation where OpenStack
services are binded to IPv6 addresses.

While testing such a setup, it is observed that some of the parameters
are not configurable/set by devstack. Because of this, the respective
openstack components would use the default values for some parameters
(which generally fall-back to using the IPv4 address of the host).

This patch would help us in configuring the required parameters, to achieve
an IPv6 based OpenStack setup.

Closes-Bug: #1447692
Change-Id: If13e60ee879395e07f26c0094b1b4c0dd481bd51