### PR TITLE
stackrc GIT_BASE variable change to https

### DIFF
--- a/stackrc
+++ b/stackrc
@@ -160,8 +160,8 @@ USE_CONSTRAINTS=$(trueorfalse False USE_CONSTRAINTS)
 # ------------
 
 # Base GIT Repo URL
-# Another option is https://git.openstack.org
-GIT_BASE=${GIT_BASE:-git://git.openstack.org}
+# Another option is git://git.openstack.org
+GIT_BASE=${GIT_BASE:-https://git.openstack.org}
 
 # Which libraries should we install from git instead of using released
 # versions on pypi?


### PR DESCRIPTION
Swapping variables on git clone, https is more generally available than git:// on networks around the world to clone with (as clients), and more secure.