### PR TITLE
Checked with LinuxMint-17.2. and added support

### DIFF
--- a/stack.sh
+++ b/stack.sh
@@ -192,7 +192,7 @@ source $TOP_DIR/stackrc
 
 # Warn users who aren't on an explicitly supported distro, but allow them to
 # override check and attempt installation with ``FORCE=yes ./stack``
-if [[ ! ${DISTRO} =~ (trusty|vivid|wily|7.0|wheezy|sid|testing|jessie|f21|f22|f23|rhel7) ]]; then
+if [[ ! ${DISTRO} =~ (trusty|vivid|wily|7.0|wheezy|sid|testing|jessie|f21|f22|f23|rhel7|LinuxMint-17.2.) ]]; then
     echo "WARNING: this script has not been tested on $DISTRO"
     if [[ "$FORCE" != "yes" ]]; then
         die $LINENO "If you wish to run this script anyway run with FORCE=yes"


### PR DESCRIPTION
The devstack works fine with destro : LinuxMint-17.2.
So updated the destro check line and added LinuxMint-17.2.

```
if [[ ! ${DISTRO} =~ (trusty|vivid|wily|7.0|wheezy|sid|testing|jessie|f21|f22|f23|rhel7|LinuxMint-17.2.) ]]; then
```

Otherwise it gives the below error for LinuxMint-17.2.:
```
` echo "WARNING: this script has not been tested on LinuxMint-17.2."`
`die 198 "If you wish to run this script anyway run with FORCE=yes"`
```