### PR TITLE
changing the URL of GIT_BASE, as openstack.org git url is not working

### DIFF
--- a/stackrc
+++ b/stackrc
@@ -173,7 +173,7 @@ GIT_TIMEOUT=${GIT_TIMEOUT:-0}
 
 # Base GIT Repo URL
 # Another option is https://git.openstack.org
-GIT_BASE=${GIT_BASE:-git://git.openstack.org}
+GIT_BASE=${GIT_BASE:-https://github.com}
 
 # The location of REQUIREMENTS once cloned
 REQUIREMENTS_DIR=$DEST/requirements


### PR DESCRIPTION
the GIT_BASE provided is not working while cloning , so changing it to https://github.com will work