### PR TITLE
making the copy command sudo in functions-common

### DIFF
--- a/functions-common
+++ b/functions-common
@@ -724,10 +724,10 @@ function install_default_policy {
     local sample_policy_dir="${project_dir}/etc/${project}/policy.d"
 
     # first copy any policy.json
-    cp -p $sample_conf_dir/policy.json $conf_dir
+    sudo cp -p $sample_conf_dir/policy.json $conf_dir
     # then optionally copy over policy.d
     if [[ -d $sample_policy_dir ]]; then
-        cp -r $sample_policy_dir $conf_dir/policy.d
+        sudo cp -r $sample_policy_dir $conf_dir/policy.d
     fi
 }
 


### PR DESCRIPTION
sometimes the copy command will throw the error , as we are running the commands using sudo user. 

changed  cp -p $sample_conf_dir/policy.json $conf_dir to sudo cp -p $sample_conf_dir/policy.json $conf_dir   in line  number 727