### PR TITLE
Fix RHEL_RDO_REPO_RPM for current version

### DIFF
--- a/stack.sh
+++ b/stack.sh
@@ -275,7 +275,7 @@ EOF
     is_package_installed yum-utils || install_package yum-utils
     sudo yum-config-manager --enable rhel-7-server-optional-rpms
 
-    RHEL_RDO_REPO_RPM=${RHEL7_RDO_REPO_RPM:-"https://repos.fedorapeople.org/repos/openstack/openstack-kilo/rdo-release-kilo-1.noarch.rpm"}
+    RHEL_RDO_REPO_RPM=${RHEL7_RDO_REPO_RPM:-"https://repos.fedorapeople.org/repos/openstack/openstack-kilo/rdo-release-kilo-2.noarch.rpm"}
 
     if ! sudo yum repolist enabled 'openstack-*' | grep -q 'openstack-'; then
         echo "RDO repo not detected; installing"


### PR DESCRIPTION
The https://repos.fedorapeople.org/repos/openstack/openstack-kilo/rdo-release-kilo-1.noarch.rpm was replaced by https://repos.fedorapeople.org/repos/openstack/openstack-kilo/rdo-release-kilo-2.noarch.rpm