### PR TITLE
Fix bug of override the content of /etc/sudoers

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -63,7 +63,7 @@ have sudo privileges:
 
 ::
 
-    $ sudo tee <<<"stack ALL=(ALL) NOPASSWD: ALL" /etc/sudoers
+    $ sudo tee -a <<<"stack ALL=(ALL) NOPASSWD: ALL" /etc/sudoers
     $ sudo su - stack
 
 Download DevStack


### PR DESCRIPTION
Fix bug of override the content of /etc/sudoers on the command 
```
$ sudo tee <<<"stack ALL=(ALL) NOPASSWD: ALL" /etc/sudoers
```