### PR TITLE
Setting SERVICE_HOST breaks etcd v3.2.

### DIFF
--- a/lib/etcd3
+++ b/lib/etcd3
@@ -45,7 +45,7 @@ function start_etcd3 {
     else
         cmd+=" --listen-peer-urls http://0.0.0.0:$ETCD_PEER_PORT "
     fi
-    cmd+=" --listen-client-urls http://$SERVICE_HOST:$ETCD_PORT"
+    cmd+=" --listen-client-urls http://$HOST_IP:$ETCD_PORT"
 
     local unitfile="$SYSTEMD_DIR/$ETCD_SYSTEMD_SERVICE"
     write_user_unit_file $ETCD_SYSTEMD_SERVICE "$cmd" "" "root"


### PR DESCRIPTION
Make --listen-client-urls use $HOST_IP
See 3.2 changelog: https://github.com/etcd-io/etcd/blob/master/Documentation/upgrades/upgrade_3_2.md#change-in---listen-peer-urls-and---listen-client-urls