### PR TITLE
fix: lib/databases/mysql: increase max connections limit to 2048 #214…

### DIFF
--- a/lib/databases/mysql
+++ b/lib/databases/mysql
@@ -150,7 +150,7 @@ function configure_database_mysql {
     # Set default db type to InnoDB
     iniset -sudo $my_conf mysqld sql_mode TRADITIONAL
     iniset -sudo $my_conf mysqld default-storage-engine InnoDB
-    iniset -sudo $my_conf mysqld max_connections 1024
+    iniset -sudo $my_conf mysqld max_connections 2048
 
     if [[ "$DATABASE_QUERY_LOGGING" == "True" ]]; then
         echo_summary "Enabling MySQL query logging"


### PR DESCRIPTION
### Bug Description
When deploying DevStack stable/2025.2 on Ubuntu 24.04 and creating instances/images via Horizon, frequent errors occurred due to MySQL hitting the max connections limit.
The default limit of 1024 in `/lib/databases/mysql` was exceeded under normal operation, causing application-level issues.

### Fix Applied
Increased the MySQL max connections limit from 1024 to 2048 in `/lib/databases/mysql`.

### Verification
After applying this change:
- MySQL connections stabilized at around 1160 during instance/image creation operations
- Horizon no longer throws connection-related errors
- Deployment continues to function normally

### Related Bug
Fixes: #2144809

![d58e648cddff62c79dbda38a4f5701a1](https://github.com/user-attachments/assets/8c43a6ce-f036-4412-9e9b-4817f5ce92f1)

![230add7ba1f0de9294bccdc0dad9a2a9](https://github.com/user-attachments/assets/23f74c6b-f843-4d74-bd52-d603aa99b09e)
![113b84b82bd3aee51e7fb63ab93c4aa4](https://github.com/user-attachments/assets/7d78cfec-b5a3-4a64-86e2-852bad851a55)
